### PR TITLE
Map CIC variants to mane select sequence

### DIFF
--- a/db/brain.yml
+++ b/db/brain.yml
@@ -97,8 +97,8 @@
 
     - name: CIC
       types:
-        - p.R202W
-        - p.R215W/Q
+        - p.R1111W
+        - p.R1124W/Q
         - truncation
 
 - type: Brain
@@ -137,8 +137,8 @@
 
     - name: CIC
       types:
-        - p.R202W
-        - p.R215W/Q
+        - p.R1111W
+        - p.R1124W/Q
         - truncation
 
 - type: Brain


### PR DESCRIPTION
I noticed that the CIC variant definitions do not align with the MANE Select transcript.

`CIC p.R215W/Q`

https://mutalyzer.nl/mapper?description=NM_015125.3%3Ac.%28643C%3ET%29&reference_id=NC_000019.10&selector_id=NM_001386298.1&slice_to=transcript&filter=true

`CIC p.R202W`

https://mutalyzer.nl/mapper?description=NM_015125.3%3Ac.%28604C%3ET%29&reference_id=NC_000019.10&selector_id=NM_001386298.1&slice_to=transcript&not_run=true